### PR TITLE
Printing stderr

### DIFF
--- a/config.go
+++ b/config.go
@@ -80,7 +80,7 @@ func getConfig(c ConfigOptions) (Configuration, error) {
 		cmd.Stderr = &stdErr
 		err := cmd.Run()
 		if err != nil {
-			log.Print(err)
+			log.Fatalf("getConfig unicreds error: %s", stdErr.String())
 		}
 		yamlData = []byte(out.String())
 	}

--- a/consul.go
+++ b/consul.go
@@ -37,7 +37,7 @@ func (c *ConfigOptions) getConsulACLToken() string {
 	cmd.Stderr = &stdErr
 	err := cmd.Run()
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("getConsulACLToken unicreds error: %s", stdErr.String())
 	}
 	output := strings.TrimSpace(out.String())
 	return output


### PR DESCRIPTION
Print out stderr if unicreds fail, also if you can't get the config we should fail instead of continuing.

Fixes #55 